### PR TITLE
Fix regex for LIBC DB

### DIFF
--- a/ropstar/leak.py
+++ b/ropstar/leak.py
@@ -46,7 +46,7 @@ class Leak():
             out = p.communicate()[0]
             out = out.decode()
             versions = []
-            pattern = ".*id (.*)\)"
+            pattern = "\((.*)\)"
             for version in out.split('\n'):
                 m = re.search(pattern, version)
                 if m:


### PR DESCRIPTION
The output format of libc db was updated, and libc was not being loaded due to an outdated regex